### PR TITLE
Handle SSE BrokenResourceError

### DIFF
--- a/src/postgres_mcp/__init__.py
+++ b/src/postgres_mcp/__init__.py
@@ -3,6 +3,7 @@ import sys
 
 from . import server
 from . import top_queries
+from .patch_sse import *  # noqa: F403
 
 
 def main():

--- a/src/postgres_mcp/patch_sse.py
+++ b/src/postgres_mcp/patch_sse.py
@@ -1,0 +1,27 @@
+import logging
+from importlib import import_module
+
+import anyio
+from starlette.responses import Response
+
+# Import dynamique du transport SSE du SDK
+sse_mod = import_module("mcp.server.sse")
+SseServerTransport = sse_mod.SseServerTransport
+
+# Sauvegarde de la méthode d'origine
+_original_connect_sse = SseServerTransport.connect_sse
+
+
+async def _safe_connect_sse(self, scope, receive, send):
+    """Capture BrokenResourceError et renvoie 204."""
+    try:
+        return await _original_connect_sse(self, scope, receive, send)
+    except anyio.BrokenResourceError:
+        logging.warning("SSE client disconnected \u2013 BrokenResourceError handled")
+        response = Response(status_code=204)
+        await response(scope, receive, send)
+        return
+
+
+# Monkey-patch
+SseServerTransport.connect_sse = _safe_connect_sse

--- a/tests/test_sse_broken_resource.py
+++ b/tests/test_sse_broken_resource.py
@@ -1,0 +1,33 @@
+from importlib import import_module
+
+import anyio
+
+import postgres_mcp.patch_sse
+
+
+def test_safe_connect_sse_handles_broken_resource(monkeypatch):
+    async def _run():
+        sse_mod = import_module("mcp.server.sse")
+        sse_transport_cls = sse_mod.SseServerTransport
+
+        async def failing_connect(self, scope, receive, send):
+            raise anyio.BrokenResourceError
+
+        monkeypatch.setattr(postgres_mcp.patch_sse, "_original_connect_sse", failing_connect, raising=False)
+
+        sse = sse_transport_cls("/msgs")
+        scope = {"type": "http"}
+
+        async def receive():
+            return {"type": "http.request", "body": b"", "more_body": False}
+
+        status = {}
+
+        async def send(message):
+            if message["type"] == "http.response.start":
+                status["code"] = message["status"]
+
+        await sse.connect_sse(scope, receive, send)
+        assert status.get("code") == 204
+
+    anyio.run(_run)


### PR DESCRIPTION
## Summary
- monkey patch `SseServerTransport.connect_sse` to return HTTP 204 on `BrokenResourceError`
- activate the patch when loading the `postgres_mcp` package
- test the new behaviour

## Testing
- `pytest -q -k "not integration"`

------
https://chatgpt.com/codex/tasks/task_e_685580260dec832a897993805779749e